### PR TITLE
fix: loader does not appear in local urls

### DIFF
--- a/src/components/Upload.js
+++ b/src/components/Upload.js
@@ -25,7 +25,7 @@ class WrappedUpload extends React.Component {
 
   componentWillMount() {
     const { component_attachment, content, componentType } = this.props;
-    if (typeof content === 'object') 
+    if (typeof content === 'object')
       this.getImageUploader()(this.props.content, null, true);
     if (component_attachment && componentType === 'File') {
       let name = component_attachment.filename.split('.')[0];
@@ -60,7 +60,7 @@ class WrappedUpload extends React.Component {
       }
     // else if (this.state.uploading && progressInfo.progress.percent === 100 && this.state.uploadProgress === 1)
     //   this.setState({ uploading: false })
-    if (externalImageResponse && 
+    if (externalImageResponse &&
         this.props.externalImageResponse !== externalImageResponse &&
         nextProps.id === externalImageResponse.client_reference_id
       ) {
@@ -215,7 +215,7 @@ class WrappedUpload extends React.Component {
           <div className="image-upload">
               {
                 //check for external image url & blur until saved on API
-                ((component_attachment.url && (component_attachment.url).includes(this.props.assetBaseUrl)) || component_attachment.content) ?
+                ((component_attachment.url && (component_attachment.url.includes(this.props.assetBaseUrl) || component_attachment.url.startsWith("/"))) || component_attachment.content) ?
                   <img
                     src={component_attachment.url || component_attachment.content}
                     width="100%"


### PR DESCRIPTION
The way I understood that code works is that it decides to set the blue and the spinner whenever the `assetBaseUrl` does not match with the url given for a file component. 
However, this approach does not work when using relative path urls where the domain is assumed to be the same as the one `cm-page-builder` is currently running it.
Now, with the additional check that the url starts with a `/`, as all working and valid relative path urls do, these will also pass this check and the loader will not get stuck indefinitely