### PR TITLE
fix: Styling not working on text components

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cm-page-builder",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Page builder package like notion",
   "main": "lib/page/index.js",
   "scripts": {

--- a/src/components/AddComponent.js
+++ b/src/components/AddComponent.js
@@ -172,8 +172,18 @@ class AddComponent extends React.Component{
     }
   }
 
+  debouncedSave = _.debounce((id, e, emitOnly = false) => {
+    this.props.updateComponent({id, newState: {content: e.target.innerHTML}, emitOnly});
+  }, 300);
+
   handleInput = (e) => {
+    e.persist();
     this.setState({showActionBtn: e.target.innerHTML === '' && !e.target.value})
+
+    // Same as onBlur
+    if(this.props.data.componentType !== 'Embed') {
+      this.debouncedSave(this.props.id, e, true)
+    }
   }
 
   // handles the focus and set the cursor to right position.
@@ -202,7 +212,7 @@ class AddComponent extends React.Component{
   }
 
   handleBlur = (e) => {
-    if(this.props.data.componentType !== 'Embed')
+    if(this.props.data.componentType !== 'Embed' && this.props.id !== this.props.currentElem.elemId)
       this.props.updateComponent({id: this.props.id, newState: {content: e.target.innerHTML}})
   }
 

--- a/src/redux/reducers/appDataReducers.js
+++ b/src/redux/reducers/appDataReducers.js
@@ -240,9 +240,9 @@ function updateComponentTypeState(state, data) {
 }
 
 function updateComponentState(state, data) {
-  let { componentData } = state;
-  let { newState, id } = data;
-  componentData = componentData.map((component) => {
+  const { componentData } = state;
+  let { newState, id, emitOnly } = data;
+  const newComponentData = componentData.map((component) => {
     if (component.id === id) {
       return {
         ...component,
@@ -254,7 +254,7 @@ function updateComponentState(state, data) {
     }
   });
   emitUpdate({ id, ...newState }, "update");
-  return { componentData };
+  return emitOnly ? state : { componentData: newComponentData};
 }
 
 function removeComponentFromState(state, data) {


### PR DESCRIPTION
- Add check back in `onBlur` to avoid moving cursor when user clicks on styling popup
- Update the input handler to emit updates as the user types
- Handle cursor shift on input by only emitting changes. Redux store updates are done in `onBlur`, just like before